### PR TITLE
Always use vagrant-embedded chef-zero gem

### DIFF
--- a/lib/vagrant-chef-zero/server_helpers.rb
+++ b/lib/vagrant-chef-zero/server_helpers.rb
@@ -6,7 +6,8 @@ module VagrantPlugins
         port = get_port(env)
         host = get_host(env)
         if ! chef_zero_server_running?(port)
-          proc = IO.popen("chef-zero --host #{host} --port #{port} 2>&1 > /dev/null")
+          proc = IO.popen("#{ENV['HOME']}/.vagrant.d/gems/bin/chef-zero "+
+                          "--host #{host} --port #{port} 2>&1 > /dev/null")
           env[:chef_zero].ui.info("Starting Chef Zero at http://#{host}:#{port}")
         end
         while ! chef_zero_server_running?(port)


### PR DESCRIPTION
First of all, thanks for this! Finally I can test cookbooks that use search in a sane way.

If you have chef-zero installed outside of Vagrant (e.g. with rbenv)
this can happen:

```
$ vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
[default] Importing base box 'opscode_ubuntu-12.04_provisionerless'...
[default] Matching MAC address for NAT networking...
[default] Setting the name of the VM...
[default] Clearing any previously set forwarded ports...
[Chef Zero] Starting Chef Zero at http://192.168.1.10:4000
/Users/mcornick/.rbenv/versions/1.9.3-p429/lib/ruby/1.9.1/rubygems/custom_require.rb:55:in `require': dlopen(/Users/mcornick/.vagrant.d/gems/gems/puma-1.6.3/lib/puma/puma_http11.bundle, 9): Library not loaded: @executable_path/../lib/libruby.1.9.1.dylib (LoadError)
  Referenced from: /Users/mcornick/.vagrant.d/gems/gems/puma-1.6.3/lib/puma/puma_http11.bundle
  Reason: image not found - /Users/mcornick/.vagrant.d/gems/gems/puma-1.6.3/lib/puma/puma_http11.bundle
    from /Users/mcornick/.rbenv/versions/1.9.3-p429/lib/ruby/1.9.1/rubygems/custom_require.rb:55:in `require'
    from /Users/mcornick/.vagrant.d/gems/gems/puma-1.6.3/lib/puma/server.rb:12:in `<top (required)>'
    from /Users/mcornick/.rbenv/versions/1.9.3-p429/lib/ruby/1.9.1/rubygems/custom_require.rb:55:in `require'
    from /Users/mcornick/.rbenv/versions/1.9.3-p429/lib/ruby/1.9.1/rubygems/custom_require.rb:55:in `require'
    from /Users/mcornick/.vagrant.d/gems/gems/puma-1.6.3/lib/puma.rb:14:in `<top (required)>'
    from /Users/mcornick/.rbenv/versions/1.9.3-p429/lib/ruby/1.9.1/rubygems/custom_require.rb:55:in `require'
    from /Users/mcornick/.rbenv/versions/1.9.3-p429/lib/ruby/1.9.1/rubygems/custom_require.rb:55:in `require'
    from /Users/mcornick/.vagrant.d/gems/gems/chef-zero-1.5/lib/chef_zero/server.rb:20:in `<top (required)>'
    from /Users/mcornick/.rbenv/versions/1.9.3-p429/lib/ruby/1.9.1/rubygems/custom_require.rb:55:in `require'
    from /Users/mcornick/.rbenv/versions/1.9.3-p429/lib/ruby/1.9.1/rubygems/custom_require.rb:55:in `require'
    from /Users/mcornick/.vagrant.d/gems/gems/chef-zero-1.5/bin/chef-zero:7:in `<top (required)>'
    from /Users/mcornick/.rbenv/versions/1.9.3-p429/bin/chef-zero:23:in `load'
    from /Users/mcornick/.rbenv/versions/1.9.3-p429/bin/chef-zero:23:in `<main>'
[Chef Zero] Waiting for Chef Zero to start
[Chef Zero] Waiting for Chef Zero to start
[Chef Zero] Waiting for Chef Zero to start
```

And chef-zero never starts. This change ensures that we run the
chef-zero installed into Vagrant's embedded ruby as a dependency of this
plugin, not some other chef-zero that may otherwise be in the $PATH.
