### PR TITLE
change server_helpers to use chef-zero's start_background to start the server

### DIFF
--- a/lib/vagrant-chef-zero/env.rb
+++ b/lib/vagrant-chef-zero/env.rb
@@ -7,6 +7,9 @@ module VagrantPlugins
       # @return [Vagrant::UI::Colored]
       attr_accessor :ui
 
+      # @return [ChefZero::Server]
+      attr_accessor :server
+
       def initialize
         @ui = ::Vagrant::UI::Colored.new.scope('Chef Zero')
       end

--- a/lib/vagrant-chef-zero/plugin.rb
+++ b/lib/vagrant-chef-zero/plugin.rb
@@ -37,6 +37,8 @@ module VagrantPlugins
 
       action_hook(:chef_zero_up, :machine_action_up, &method(:provision))
 
+      action_hook(:chef_zero_reload, :machine_action_reload, &method(:provision))
+
       action_hook(:chef_zero_provision, :machine_action_provision, &method(:provision))
 
       action_hook(:chef_zero_provision, :machine_action_reload, &method(:provision))

--- a/lib/vagrant-chef-zero/server_helpers.rb
+++ b/lib/vagrant-chef-zero/server_helpers.rb
@@ -3,42 +3,28 @@ module VagrantPlugins
     module ServerHelpers
 
       def start_chef_zero(env)
+        require 'chef_zero/server'
+
         port = get_port(env)
         host = get_host(env)
-        if ! chef_zero_server_running?(port)
-          vagrant_gems = ENV['GEM_PATH'].split(':').select { |gp| gp.include?('vagrant.d')}.first
-          chef_zero_binary = ::File.join(vagrant_gems, "bin", "chef-zero")
-          proc = IO.popen("#{chef_zero_binary} --host #{host} --port #{port} 2>&1 > /dev/null")
+        unless env[:chef_zero].server && env[:chef_zero].server.running?
           env[:chef_zero].ui.info("Starting Chef Zero at http://#{host}:#{port}")
+          env[:chef_zero].server = ::ChefZero::Server.new(port: port, host: host)
+          env[:chef_zero].server.start_background
         end
-        while ! chef_zero_server_running?(port)
+
+        until env[:chef_zero].server.running?
           sleep 1
           env[:chef_zero].ui.warn("Waiting for Chef Zero to start")
         end
       end
 
       def stop_chef_zero(env)
-        port = get_port(env)
-        if chef_zero_server_running?(port)
-          pid = get_chef_zero_server_pid(port)
+        if env[:chef_zero].server && env[:chef_zero].server.running?
           env[:chef_zero].ui.info("Stopping Chef Zero")
-          system("kill #{pid}")
+          env[:chef_zero].server.stop
         end
       end
-
-      def chef_zero_server_running?(port)
-        pid = get_chef_zero_server_pid(port)
-        !! pid
-      end
-
-      def get_chef_zero_server_pid(port)
-        pid = %x[ lsof -i tcp:#{port} | grep -E 'ruby|chef-zero' | awk '{print $2}' ]
-        if pid && pid != ""
-          return pid
-        end
-        return nil
-      end
-
     end
   end
 end


### PR DESCRIPTION
This way we don't have to hunt for the correct PID to kill. Also it should work just fine in Windows where lsof isn't a command.
