### PR TITLE
Only set the berkshelf client key if unset

### DIFF
--- a/lib/vagrant-chef-zero/env_helpers.rb
+++ b/lib/vagrant-chef-zero/env_helpers.rb
@@ -111,7 +111,7 @@ module VagrantPlugins
 
       def set_berkshelf_client_key(value)
         ObjectSpace.each_object(Berkshelf::Config).each do |o|
-          o.chef.client_key = value
+          o.chef.client_key ||= value
         end
       end
 


### PR DESCRIPTION
Unconditionally overriding the client key makes it impossible for Berkshelf to pull dependencies from a chef_api source.
