### PR TITLE
add support for Ruby DSL Role and Environment files

### DIFF
--- a/vagrant-chef-zero.gemspec
+++ b/vagrant-chef-zero.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "chef-zero", "~> 1.3"
   s.add_dependency "ridley", ">= 1.0.0"
-
+  s.add_dependency "chef", "~> 11.0"
 
   # Stolen from Vagrant Berkshelf because Ruby hates dependency resolution
   # activesupport 3.2.13 contains an incompatible hard lock on i18n (= 0.6.1)


### PR DESCRIPTION
This adds support for uploading Roles and Environments by reading the .rb files and converting them to json on the fly. It adds the chef gem as a dependency, which is the current easiest way to read in the files. Works like a champ with a mix of .rb and .json files, like in https://github.com/stackforge/openstack-chef-repo
