### PR TITLE
expand all paths in config

### DIFF
--- a/lib/vagrant-chef-zero/config.rb
+++ b/lib/vagrant-chef-zero/config.rb
@@ -40,7 +40,7 @@ module VagrantPlugins
       attr_reader :chef_repo_path
 
       def chef_repo_path=(path)
-        @chef_repo_path = path
+        @chef_repo_path = File.expand_path(path)
         @roles = path_exists?("#{path}/roles") ? "#{path}/roles" : nil
         @environments = path_exists?("#{path}/environments") ? "#{path}/environments" : nil
         @nodes = path_exists?("#{path}/nodes") ? "#{path}/nodes" : nil
@@ -70,14 +70,18 @@ module VagrantPlugins
       def finalize!
         @enabled = true if @enabled == UNSET_VALUE
         @roles = nil if @roles == UNSET_VALUE
+        @roles = File.expand_path(@roles) if @roles
         @environments = nil if @environments == UNSET_VALUE
+        @environments = File.expand_path(@environments) if @environments
         @nodes = nil if @nodes == UNSET_VALUE
+        @nodes = File.expand_path(@nodes) if @nodes
         @cookbooks = nil if @cookbooks == UNSET_VALUE
+        @cookbooks = File.expand_path(@cookbooks) if @cookbooks
         @data_bags = nil if @data_bags == UNSET_VALUE
+        @data_bags = File.expand_path(@data_bags) if @data_bags
         @chef_repo_path = nil if @chef_repo_path == UNSET_VALUE
         {}
       end
-
     end
   end
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -9,7 +9,7 @@ describe "VagrantPlugins::ChefZero::Config" do
 
   describe "config object is created" do
 
-    it "should set all paths to nil" do 
+    it "should set all paths to nil" do
       d = DummyClass.new
       d.finalize!
       d.chef_repo_path.should eql nil
@@ -22,15 +22,15 @@ describe "VagrantPlugins::ChefZero::Config" do
 
   end
 
-  describe "chef_repo_path is the only defined path" do 
-    
+  describe "chef_repo_path is the only defined path" do
+
     it "chef_repo_path should be set" do
       d = DummyClass.new
       d.chef_repo_path = "/foo"
       d.finalize!
       d.chef_repo_path.should eql "/foo"
     end
-    
+
 
     it "should use sane defaults and prefix all fixture paths with the chef_repo_path" do
       DummyClass.any_instance.stub(:path_exists?).and_return(true)
@@ -59,7 +59,7 @@ describe "VagrantPlugins::ChefZero::Config" do
     end
   end
 
-  describe "chef_repo_path is defined" do 
+  describe "chef_repo_path is defined" do
 
     describe "specific fixture path is also defined" do
 
@@ -77,7 +77,24 @@ describe "VagrantPlugins::ChefZero::Config" do
         d.data_bags.should eql "/foo/data_bags"
       end
 
+      it "should allow using ~ in the path" do
+        oldhome = ENV['HOME']
+        ENV['HOME'] = '/home/user'
+        DummyClass.any_instance.stub(:path_exists?).and_return(true)
+        d = DummyClass.new
+        d.chef_repo_path = "~/foo"
+        d.data_bags = "~/bar/data_bags"
+        d.finalize!
+
+        d.roles.should eql "/home/user/foo/roles"
+        d.environments.should eql "/home/user/foo/environments"
+        d.nodes.should eql "/home/user/foo/nodes"
+        d.cookbooks.should eql "/home/user/foo/cookbooks"
+        d.data_bags.should eql "/home/user/bar/data_bags"
+        ENV['HOME'] = oldhome
+      end
+
     end
   end
-  
+
 end


### PR DESCRIPTION
Allows using ~/.data_bags and other similar paths, which
makes it much easier to share configs on many cookbooks.