### PR TITLE
Make sure we don't get similarly named gems

### DIFF
--- a/lib/vagrant-chef-zero/server_helpers.rb
+++ b/lib/vagrant-chef-zero/server_helpers.rb
@@ -45,7 +45,7 @@ module VagrantPlugins
         # Assuming a path from Gem.path
         #potential_binary = ::File.join(path, "bin", "chef-zero")
         gems_path = ::File.join(path, "gems")
-        chef_zero_gem = Dir["#{gems_path}/*"].select { |gp| gp.include?('chef-zero')}.first
+        chef_zero_gem = Dir["#{gems_path}/*"].select { |gp| gp.include?('/chef-zero-')}.first
         if chef_zero_gem
           return ::File.join(chef_zero_gem, "bin", "chef-zero")
         else


### PR DESCRIPTION
Was finding the vagrant-chef-zero gem before the actual chef-zero gem:

/home/mike/.vagrant.d/gems/gems/vagrant-chef-zero-0.5.2/bin/chef-zero
/home/mike/.vagrant.d/gems/gems/vagrant-chef-zero-0.5.2/bin/chef-zero

[Chef Zero] Could not find Chef Zero binary in any path in ["/home/mike/.vagrant.d/gems", "/opt/vagrant/bin/../embedded/gems"]
