### PR TITLE
Fix proper shutdown of chef_zero

### DIFF
--- a/lib/vagrant-chef-zero/server_helpers.rb
+++ b/lib/vagrant-chef-zero/server_helpers.rb
@@ -110,7 +110,7 @@ module VagrantPlugins
 
       def kill_process(env, pid)
         env[:chef_zero].ui.info("Stopping Chef Zero")
-        system("kill -s SIGTERM #{pid}")
+        system("kill -s TERM #{pid}")
       end
 
       def get_chef_zero_server_pid(port)


### PR DESCRIPTION
s/SIGTERM/TERM/, correct signal specification for kill command. On Linux and Mac, the signal is specified without the SIG prefix.
