### PR TITLE
Added support for the Vagrant 1.5 UI object

### DIFF
--- a/lib/vagrant-chef-zero/env.rb
+++ b/lib/vagrant-chef-zero/env.rb
@@ -10,7 +10,12 @@ module VagrantPlugins
       attr_accessor :server
 
       def initialize
-        @ui = ::Vagrant::UI::Colored.new.scope('Chef Zero')
+        vagrant_version = Gem::Version.new(::Vagrant::VERSION)
+        if vagrant_version >= Gem::Version.new("1.5")
+          @ui = ::Vagrant::UI::Colored.new
+          @ui.opts[:target] = 'Chef Zero'
+        else
+          @ui = ::Vagrant::UI::Colored.new.scope('Chef Zero')
       end
     end
   end


### PR DESCRIPTION
The UI object in Vagrant 1.5 takes no constructor arguments. 

Change borrowed from https://github.com/sneal/vagrant-butcher/commit/80c87eaef0fa8ab17362b9eaad41033dd2cccbe7

Fixes #41

Still needs tests.
