### PR TITLE
Vagrant version specific logging (Fixes #41)

### DIFF
--- a/lib/vagrant-chef-zero/env.rb
+++ b/lib/vagrant-chef-zero/env.rb
@@ -10,7 +10,15 @@ module VagrantPlugins
       attr_accessor :server
 
       def initialize
-        @ui = ::Vagrant::UI::Colored.new.scope('Chef Zero')
+        vagrant_version = Gem::Version.new(::Vagrant::VERSION)
+        if vagrant_version >= Gem::Version.new('1.5')
+          @ui = ::Vagrant::UI::Colored.new
+          @ui.opts[:target] = 'Chef Zero'
+        elsif vagrant_version >= Gem::Version.new('1.2')
+          @ui = ::Vagrant::UI::Colored.new.scope('Chef Zero')
+        else
+          @ui = ::Vagrant::UI::Colored.new('Chef Zero')
+        end
       end
     end
   end


### PR DESCRIPTION
Vagrant changed it's logging API in version 1.5. This pull request fixes issue #41 by using the correct logging API based on the version of Vagrant that is loaded. The source from this was copied from https://github.com/sneal/vagrant-butcher/commit/80c87eaef0fa8ab17362b9eaad41033dd2cccbe7
