### PR TITLE
Upload the cookbook even if the version already exists and is frozen on the target chef server

### DIFF
--- a/lib/vagrant-chef-zero/action/upload.rb
+++ b/lib/vagrant-chef-zero/action/upload.rb
@@ -39,7 +39,7 @@ module VagrantPlugins
           cookbooks.each do |cookbook|
             name = File.basename(cookbook)
             env[:chef_zero].ui.info("Uploading Cookbook #{name}")
-            @conn.cookbook.upload(cookbook, options: {name: name})
+            @conn.cookbook.upload(cookbook, options = { force: true })
           end
         end
 


### PR DESCRIPTION
This commit fixes #58 and allows to upload the cookbook even if the version already exists and is frozen on the target chef server.