### PR TITLE
Add support for vagrant 1.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ sudo: false
 cache: bundler
 rvm:
   - 2.1.2
-script: rake
+script: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 notifications:
   email:
-    - int-toolkit@schubergphilis.com
+    - mferreira@schubergphilis.com
+sudo: false
+cache: bundler
 rvm:
   - 2.1.2
 script: rake

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Vagrant-Chef-Zero
 [![Build Status](https://travis-ci.org/schubergphilis/vagrant-chef-zero.svg)](https://travis-ci.org/schubergphilis/vagrant-chef-zero)
 [![Code Climate](https://codeclimate.com/github/schubergphilis/vagrant-chef-zero.png)](https://codeclimate.com/github/schubergphilis/vagrant-chef-zero)
-[![Dependency Status](https://gemnasium.com/schubergphilis/vagrant-chef-zero.png)](https://gemnasium.com/schubergphilis/vagrant-chef-zero)
 [![Coverage Status](https://coveralls.io/repos/schubergphilis/vagrant-chef-zero/badge.png)](https://coveralls.io/r/schubergphilis/vagrant-chef-zero)
 [![Gem Version](https://badge.fury.io/rb/vagrant-chef-zero.svg)](http://badge.fury.io/rb/vagrant-chef-zero)
 

--- a/lib/vagrant-chef-zero/action/upload.rb
+++ b/lib/vagrant-chef-zero/action/upload.rb
@@ -1,5 +1,3 @@
-require 'chef'
-
 module VagrantPlugins
   module ChefZero
     module Action
@@ -67,9 +65,7 @@ module VagrantPlugins
           environments = select_items(path)
           environments.each do |e|
             if e =~ /.rb$/
-              envrb = ::Chef::Environment.new
-              envrb.from_file(e)
-              environment = envrb.to_hash
+              env[:chef_zero].ui.error("Cannot upload environments defined in ruby files: #{e}")
             else
               environment = JSON.parse(IO.read(e)).to_hash
             end
@@ -90,9 +86,7 @@ module VagrantPlugins
           roles = select_items(path)
           roles.each do |r|
             if r =~ /.rb$/
-              rrb = ::Chef::Role.new
-              rrb.from_file(r)
-              role = rrb.to_hash
+              env[:chef_zero].ui.error("Cannot upload roles defined in ruby files: #{r}")
             else
               role = JSON.parse(IO.read(r)).to_hash
             end
@@ -198,9 +192,7 @@ module VagrantPlugins
           end
           @conn
         end
-
       end
-
     end
   end
 end

--- a/test/fixtures/cookbooks/test_vagrant_chef_zero/chefignore
+++ b/test/fixtures/cookbooks/test_vagrant_chef_zero/chefignore
@@ -1,0 +1,12 @@
+*file
+*file.lock
+bin
+bundle
+chefignore
+spec
+test
+vendor
+.git
+.*
+dev.*
+*_dev

--- a/test/fixtures/cookbooks/test_vagrant_chef_zero/metadata.rb
+++ b/test/fixtures/cookbooks/test_vagrant_chef_zero/metadata.rb
@@ -1,0 +1,8 @@
+name             'test_vagrant_chef_zero'
+maintainer       'The Authors'
+maintainer_email 'you@example.com'
+license          'all_rights'
+description      'Installs/Configures test_vagrant_chef_zero'
+long_description 'Installs/Configures test_vagrant_chef_zero'
+version          '0.1.0'
+

--- a/test/fixtures/cookbooks/test_vagrant_chef_zero/recipes/default.rb
+++ b/test/fixtures/cookbooks/test_vagrant_chef_zero/recipes/default.rb
@@ -1,0 +1,1 @@
+log 'Converging test_vagrant_chef_zero::default'

--- a/test/fixtures/environments/test.json
+++ b/test/fixtures/environments/test.json
@@ -1,0 +1,15 @@
+{
+  "name": "test",
+  "description": "",
+  "cookbook_versions": {
+
+  },
+  "json_class": "Chef::Environment",
+  "chef_type": "environment",
+  "default_attributes": {
+
+  },
+  "override_attributes": {
+
+  }
+}

--- a/test/fixtures/roles/test.json
+++ b/test/fixtures/roles/test.json
@@ -1,0 +1,15 @@
+{
+  "name": "test",
+  "description": "",
+  "cookbook_versions": {
+
+  },
+  "json_class": "Chef::Role",
+  "chef_type": "role",
+  "default_attributes": {
+
+  },
+  "override_attributes": {
+
+  }
+}

--- a/test/integration/Vagrantfile
+++ b/test/integration/Vagrantfile
@@ -1,0 +1,49 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+test_machines = {
+  'windows' => {
+    'box'          => ENV['VAGRANT_TEST_WINDOWS_BOX'], # sbp_windows_2012_r2_20141211_1
+    'communicator' => :winrm,
+    'guest'        => :windows
+  },
+  'centos' => {
+    'box' => ENV['VAGRANT_TEST_CENTOS_BOX'], # opscode-centos-7.1
+    'communicator' => :ssh,
+    'guest'        => :linux
+  }
+}
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |global_config|
+  test_machines.each_pair do |name, options|
+    global_config.vm.define name do |config|
+
+      config.vm.box     = options['box']
+
+      config.vm.communicator = options['communicator']
+      config.vm.guest        = options['guest']
+
+      config.vm.provider 'virtualbox' do |vb|
+        vb.gui = true
+      end
+
+      config.berkshelf.enabled = true
+
+      config.omnibus.chef_version = 'latest'
+
+      config.chef_zero.cookbooks    = [ '../fixtures/cookbooks' ]
+      config.chef_zero.environments = '../fixtures/environments'
+      config.chef_zero.roles        = '../fixtures/roles'
+
+      config.vm.provision 'chef_client', run: 'always' do |chef|
+        chef.environment = 'test'
+        chef.add_role      'test'
+        chef.log_level   = 'info'
+        chef.run_list    = [ 'recipe[test_vagrant_chef_zero::default]' ]
+      end
+    end
+  end
+end

--- a/vagrant-chef-zero.gemspec
+++ b/vagrant-chef-zero.gemspec
@@ -5,11 +5,11 @@ Gem::Specification.new do |s|
   s.name          = "vagrant-chef-zero"
   s.version       = VagrantPlugins::ChefZero.get_version()
   s.platform      = Gem::Platform::RUBY
-  s.authors       = "Andrew Gross"
-  s.email         = "andrew.w.gross@gmail.com"
-  s.homepage      = "http://github.com/andrewgross/vagrant-chef-zero"
-  s.summary       = "Enables Vagrant to interact with Chef Zero."
-  s.description   = "Enables Vagrant to interact with Chef Zero"
+  s.authors       = "Andrew Gross, Miguel Ferreira, Timothy van Zadelhoff"
+  s.email         = "andrew.w.gross@gmail.com, miguelferreira@me.com"
+  s.homepage      = "http://github.com/schubergphilis/vagrant-chef-zero"
+  s.summary       = "Enables Vagrant to spawn a Chef Zero instance that is shared by all VMs."
+  s.description   = "Enables Vagrant to spawn a Chef Zero instance that is shared by all VMs."
 
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-chef-zero"

--- a/vagrant-chef-zero.gemspec
+++ b/vagrant-chef-zero.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "chef-zero", "~> 2.0"
   s.add_dependency "ridley", ">= 1.0.0"
-  s.add_dependency "chef", "~> 11.0"
 
   s.add_development_dependency "bump", "~> 0.5.2"
 


### PR DESCRIPTION
Vagrant 1.8.1 depends on `net-ssh (~> 3.0.1)` and the chef gem depends on `net-ssh (~> 2.6)`. In order to support vagrant 1.8.1 the chef gem had to be dropped. That means that uploading environments and roles as `*.rb` won't work anymore (and that's actually what the README always said).

Fixes #75 